### PR TITLE
Fix depecrated L.Mixin.Events

### DIFF
--- a/src/leaflet.trackplayback/clock.js
+++ b/src/leaflet.trackplayback/clock.js
@@ -4,7 +4,7 @@ import L from 'leaflet'
  */
 export const Clock = L.Class.extend({
 
-  includes: L.Mixin.Events,
+  includes: L.Evented.prototype || L.Mixin.Events,
 
   options: {
     // 播放速度

--- a/src/leaflet.trackplayback/trackplayback.js
+++ b/src/leaflet.trackplayback/trackplayback.js
@@ -23,7 +23,7 @@ import * as Util from './util'
  */
 export const TrackPlayBack = L.Class.extend({
 
-  includes: L.Mixin.Events,
+  includes: L.Evented.prototype || L.Mixin.Events,
 
   initialize: function (data, map, options = {}) {
     let drawOptions = {


### PR DESCRIPTION
This plugin created for leaflet > 1.0.0
now in leaflet 1.7.1 `L.Mixin.Events` was deprecated so it must change to `L.Evented`

see https://github.com/ptv-logistics/Leaflet.NonTiledLayer/issues/21